### PR TITLE
feat: Supporting GitHubs new draft status for PRs

### DIFF
--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -15,5 +15,9 @@ module.exports = {
   labelMerged: {
     name: "PR: merged",
     color: "6f42c1"
+  },
+  labelDraft: {
+    name: "PR: draft",
+    color: "ccc"
   }
 };

--- a/lib/pr-triage.js
+++ b/lib/pr-triage.js
@@ -15,7 +15,8 @@ class PRTriage {
       UNREVIED: "labelUnreviewed",
       APPROVED: "labelApproved",
       CHANGES_REQUESTED: "labelChangesRequested",
-      MERGED: "labelMerged"
+      MERGED: "labelMerged",
+      DRAFT: "labelDraft"
     });
   }
 
@@ -41,6 +42,7 @@ class PRTriage {
       case PRTriage.STATE.UNREVIED:
       case PRTriage.STATE.CHANGES_REQUESTED:
       case PRTriage.STATE.APPROVED:
+      case PRTriage.STATE.DRAFT:
       case PRTriage.STATE.MERGED:
         this._updateLabel(state);
         this.logger(
@@ -63,6 +65,8 @@ class PRTriage {
       return PRTriage.STATE.WIP;
     } else if (this.pullRequest.state === "closed" && this.pullRequest.merged) {
       return PRTriage.STATE.MERGED;
+    } else if (this.pullRequest.draft) {
+      return PRTriage.STATE.DRAFT;
     }
 
     const reviews = await this._getUniqueReviews();

--- a/test/fixtures/payload.json
+++ b/test/fixtures/payload.json
@@ -1,6 +1,12 @@
 {
   "pull_request": {
     "with": {
+      "draft": {
+	"data": {
+	  "title": "Draft pull request",
+	  "draft": true
+	}
+      },
       "wip_title": {
         "data": {
           "title": "WIP: pull request is work in progress"

--- a/test/pr-triage.test.js
+++ b/test/pr-triage.test.js
@@ -14,7 +14,8 @@ describe("PRTriage", () => {
       UNREVIED: expect.any(String),
       APPROVED: expect.any(String),
       CHANGES_REQUESTED: expect.any(String),
-      MERGED: expect.any(String)
+      MERGED: expect.any(String),
+      DRAFT: expect.any(String)
     });
   }); // static STATE
 
@@ -32,6 +33,18 @@ describe("PRTriage", () => {
    * _getState
    */
   describe("_getState", () => {
+    describe("when pull request is draft", () => {
+      const klass = new PRTriage({}, { owner, repo });
+      const subject = () => klass._getState();
+
+      test("should be STATE.DRAFT", async () => {
+	klass.pullRequest =
+	  payload["pull_request"]["with"]["draft"]["data"];
+	const result = await subject();
+	expect(result).toEqual(PRTriage.STATE.DRAFT)
+      });
+    });
+
     describe("when pull request title include WIP regex", () => {
       const klass = new PRTriage({}, { owner, repo });
       const subject = () => klass._getState();
@@ -220,7 +233,7 @@ describe("PRTriage", () => {
   describe("_ensurePRTriageLabelExists", () => {
     const klass = new PRTriage({}, { owner, repo });
     klass._createLabel = jest.fn().mockReturnValue(Promise.resolve({}));
-    const n = 4;
+    const n = 5;
 
     test(`createLabel() should be called ${n} times`, async () => {
       await klass._ensurePRTriageLabelExists();


### PR DESCRIPTION
Github announced new draft status for PRs.
https://developer.github.com/changes/2019-02-14-draft-pull-requests/

fix #164